### PR TITLE
Support coddled conversion values

### DIFF
--- a/conversion.js
+++ b/conversion.js
@@ -78,7 +78,7 @@ const unitPattern = Object.keys(unitMap)
   .join('|');
 
 const regexp = new RegExp(
-  `(?<=^|\\s)(-?\\d+(?:\\.\\d+)?)(?:\\s)?(${unitPattern})(?=\\s|$|[.,;!?:])`,
+  `(?<!\\w)(-?\\d+(?:\\.\\d+)?)(?:\\s)?(${unitPattern})\\b`,
   'gi'
 );
 

--- a/conversion.test.js
+++ b/conversion.test.js
@@ -39,6 +39,17 @@ describe('conversion unit tests', () => {
     expect(make('20 mi')).toBe('20 mi = 32.19 km\n');
   });
 
+  it('should handle symbolically coddled expressions', () => {
+    expect(make('~2.5 meters')).toBe('2.5 m = 8.2 ft\n');
+    expect(make('2.5 meters)')).toBe('2.5 m = 8.2 ft\n');
+    expect(make('(~2.5 meters)')).toBe('2.5 m = 8.2 ft\n');
+    expect(make('*2.5 meters*')).toBe('2.5 m = 8.2 ft\n');
+    expect(make('*-2.5 meters*')).toBe('-2.5 m = -8.2 ft\n');
+    expect(make('`-2.5 meters`')).toBe('-2.5 m = -8.2 ft\n');
+    expect(make('-2.5 meters?')).toBe('-2.5 m = -8.2 ft\n');
+    expect(make('-2.5 meters:')).toBe('-2.5 m = -8.2 ft\n');
+  });
+
   it('should have a conversion for every unit defined', () => {
     const units = new Set(Object.values(unitMap));
     for (const unit of units) {


### PR DESCRIPTION
Merr said something like `(~2.5 meters)`, and no conversion was triggered due to the surrounding symbols.

This change tweaks the regex to support these cases, and some more.