### PR TITLE
Adds "add role to all commands" and splits commands on multiple space

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,6 +140,11 @@ client.on("messageCreate", async msg => {
                 await roletoall.removeRoleFromAllCommand(msg, role, true);
             }
             break;
+        case "!usersworole":
+            if(userIsMod(msg)) {
+                role = roletoall.getRoleFromCommand(msg);
+                await roletoall.listUsersWithoutRoleCommand(msg, role); 
+            }
         default:
             break;
     }


### PR DESCRIPTION
Adds commands !addrole/!removerole [role] that adds/removes a role to all members of the server.

Also changes what the split that is used to recognizes commands to use regexp (/\s+/) instead of [space]. This allows for both !command argument and !command     argument.