### PR TITLE
Fix false substitution triggering on emojis

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,7 +153,7 @@ client.on("messageCreate", async msg => {
     let correctionResponse = "";
     const regex = new RegExp(`\\b[^\\w\\s]*(${Array.from(wordToCorrectionMap.keys()).join("|")})[^\\w\\s]*\\b`, 'ig');
     for(const match of msg.content.matchAll(regex)){
-        correctionResponse += `*${wordToCorrectionMap.get(match[0].toLowerCase())}\n`;
+        correctionResponse += `*${wordToCorrectionMap.get(match[1].toLowerCase())}\n`;
     }
     if(correctionResponse){
         msg.channel.send(correctionResponse)

--- a/index.test.js
+++ b/index.test.js
@@ -93,4 +93,11 @@ describe('index.js', () => {
         await messageCreateCallback(mockMsg);
         expect(threads.list).toHaveBeenCalledWith(mockMsg);
     });
+
+    it('should correctly substitute words from complex strings', async () => {
+        mockMsg.content = 'alt=":weezer:"';
+        const messageCreateCallback = client.getOnCallback('messageCreate');
+        await messageCreateCallback(mockMsg);
+        expect(mockMsg.channel.send).toHaveBeenCalledWith('*Weeer\n');
+    });
 });


### PR DESCRIPTION
Also added a test.

In regex match "zero" is the whole regex pattern. We want the text in the `()` since it needs to be in the word map.

Feel free to not merge this if we would rather keep the bot's quirkiness.